### PR TITLE
Implement AutoCloseable in Connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.gradle
+.idea
+/build
+*.iml

--- a/src/main/java/io/goshawkdb/client/Connection.java
+++ b/src/main/java/io/goshawkdb/client/Connection.java
@@ -1,12 +1,5 @@
 package io.goshawkdb.client;
 
-import org.capnproto.MessageBuilder;
-import org.capnproto.MessageReader;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.Arrays;
-
 import io.goshawkdb.client.capnp.ConnectionCap;
 import io.goshawkdb.client.capnp.TransactionCap;
 import io.netty.bootstrap.Bootstrap;
@@ -19,6 +12,11 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import org.capnproto.MessageBuilder;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
 
 import static io.goshawkdb.client.ConnectionFactory.BUFFER_SIZE;
 import static io.goshawkdb.client.ConnectionFactory.KEY_LEN;
@@ -28,7 +26,7 @@ import static io.goshawkdb.client.ConnectionFactory.KEY_LEN;
  * {@link ConnectionFactory}. A connection can only run one transaction at a time, and nested
  * transactions are supported.
  */
-public class Connection {
+public class Connection implements AutoCloseable {
 
     @ChannelHandler.Sharable
     private static class TxnSubmitter extends ChannelDuplexHandler {
@@ -169,6 +167,7 @@ public class Connection {
      * @throws InterruptedException if an interruption occurs whilst we're waiting for the
      *                              connection to close.
      */
+    @Override
     public void close() throws InterruptedException {
         ChannelFuture closeFuture = null;
         synchronized (lock) {
@@ -176,6 +175,7 @@ public class Connection {
                 closeFuture = connectFuture.channel().close();
             }
         }
+
         if (closeFuture != null) {
             closeFuture.sync();
         }

--- a/src/test/java/io/goshawkdb/test/SimpleSetupTest.java
+++ b/src/test/java/io/goshawkdb/test/SimpleSetupTest.java
@@ -1,0 +1,45 @@
+package io.goshawkdb.test;
+
+import io.goshawkdb.client.Certs;
+import io.goshawkdb.client.Connection;
+import io.goshawkdb.client.ConnectionFactory;
+import io.goshawkdb.client.TransactionResult;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.FileReader;
+
+import static io.goshawkdb.test.TestBase.getEnv;
+
+/**
+ * @author pidster
+ */
+public class SimpleSetupTest {
+
+    @Test
+    public void test() throws Exception {
+
+        final String clusterCertPath = getEnv("CLUSTER_CERT");
+        final String clientKeyPairPath = getEnv("CLIENT_KEYPAIR");
+
+        Certs certs = new Certs();
+        certs.addClusterCertificate("goshawkdb", new FileInputStream(clusterCertPath));
+        certs.parseClientPEM(new FileReader(clientKeyPairPath));
+
+        final String hostStr = getEnv("CLUSTER_HOSTS");
+        String[] hosts = hostStr.split(",");
+
+        ConnectionFactory factory = new ConnectionFactory();
+
+        // try-with-resources auto-closes the connection
+        try (Connection connection = factory.connect(certs, hosts[0])) {
+            TransactionResult<Integer> result = connection.runTransaction(t -> 1);
+        }
+        catch (Throwable throwable) {
+            throwable.printStackTrace();
+        }
+
+
+    }
+
+}


### PR DESCRIPTION
Makes Connection implement AutoCloseable so it can be used in a try-with-resources block.
